### PR TITLE
fix(params): allow underscores in token body regex

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -43,7 +43,7 @@ export const VALIDATION_RULES = {
   /** Regex for validating repository name */
   REPO_NAME_REGEX: /^[a-zA-Z0-9._-]+$/,
   /** Regex for validating GitHub token format */
-  TOKEN_FORMAT_REGEX: /^(ghp_|ghs_|github_pat_)[a-zA-Z0-9]{36,}$/,
+  TOKEN_FORMAT_REGEX: /^(ghp_|ghs_|github_pat_)[a-zA-Z0-9_]{36,}$/,
 } as const;
 
 // Log Message Prefixes

--- a/src/lib/params.test.ts
+++ b/src/lib/params.test.ts
@@ -53,6 +53,17 @@ describe("params", () => {
       );
     });
 
+    test("should return token when github_pat_ token contains underscores in the body", () => {
+      mockGetInput.mockReturnValue(
+        "github_pat_11AAABBB_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      );
+
+      const result = getToken();
+      expect(result).toBe(
+        "github_pat_11AAABBB_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      );
+    });
+
     test("should throw error when token is empty", () => {
       mockGetInput.mockReturnValue("");
 


### PR DESCRIPTION
Fixes #255

## Summary

- `TOKEN_FORMAT_REGEX` in `src/config/constants.ts` now includes `_` in the character class (`[a-zA-Z0-9_]`), so fine-grained PATs (`github_pat_`) whose bodies contain underscores are accepted as valid.
- Added a test case covering an org-scoped fine-grained PAT with an underscore in the body (e.g. `github_pat_11AAABBB_xxx…`).

## Root cause

GitHub fine-grained personal access tokens use the `github_pat_` prefix and commonly contain underscores after an org segment. The previous regex `[a-zA-Z0-9]{36,}` rejected any such token, causing the action to fail with *"token must be a valid GitHub token"* even when the token itself was perfectly valid.

## Test plan

- [x] All 114 existing tests pass
- [x] New test `should return token when github_pat_ token contains underscores in the body` passes