### PR TITLE
fix(params): accept ghs_ JWT-format tokens and fix docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Token validation now accepts `ghs_` installation tokens in the new JWT stateless format
+  (dots and dashes in token body), rolled out by GitHub on 2026-04-27. Validation now
+  checks only the token prefix per GitHub's 2026-04-24 guidance, treating the body as opaque.
+- Corrected documented rate-limit delay from 100ms to 350ms to match actual behaviour.
+
 ## [7] - 2025-11-03
 
 ### Added
@@ -32,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - No retries on 4xx client errors (except 429)
 - **Rate Limit Handling**: Built-in GitHub API rate limit support
   - Respects `Retry-After` headers
-  - 100ms delay between deletions
+  - 350ms delay between deletions
   - Automatic retry on rate limit errors
 - **Comprehensive Test Suite**: Increased test coverage from ~70% to 98.93%
   - 113 tests across 4 test suites

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Prevents cascading failures and API abuse:
 Built-in rate limit handling:
 - Respects GitHub API rate limits
 - Honors `Retry-After` headers
-- 100ms delay between deletions
+- 350ms delay between deletions
 - Metrics tracked via `rate-limit-hits` output
 
 ### Workflow Filtering

--- a/src/lib/params.test.ts
+++ b/src/lib/params.test.ts
@@ -64,6 +64,18 @@ describe("params", () => {
       );
     });
 
+    test("should accept ghs_ JWT-format token with dots and dashes (stateless format rolled out 2026-04-27)", () => {
+      // GitHub App installation tokens now use a stateless JWT format: ghs_APPID.HEADER.PAYLOAD
+      // See: https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/
+      // Deliberately synthetic (non-base64, low-entropy) segments to avoid triggering
+      // entropy-based secret scanners while still exercising dot and dash acceptance.
+      const jwtToken = "ghs_" + "fake-app-id.fake-header.fake-payload";
+      mockGetInput.mockReturnValue(jwtToken);
+
+      const result = getToken();
+      expect(result).toBe(jwtToken);
+    });
+
     test("should throw error when token is empty", () => {
       mockGetInput.mockReturnValue("");
 


### PR DESCRIPTION
## Summary

- Adds a test case for `ghs_` tokens in the new JWT stateless format (dots and dashes in the body), confirming the prefix-only validation introduced in #257 correctly handles them
- Adds `[Unreleased]` CHANGELOG entry documenting the token validation fix and rate-limit delay correction
- Fixes documented rate-limit delay from 100ms to 350ms in README and CHANGELOG to match the actual `RATE_LIMIT_DELAY_MS` constant

Closes #255

## Background

GitHub [announced on 2026-04-24](https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/) that `ghs_` installation tokens now come in a stateless JWT format (`ghs_APPID.HEADER.PAYLOAD`) with dots and base64url-encoded segments that can contain `-`. SocksTheWolf's comment on #255 was correct.

The code fix already landed in #257 (prefix-only regex). This PR adds the missing test coverage and doc corrections.

## Test plan

- [ ] New test `should accept ghs_ JWT-format token with dots and dashes` passes
- [ ] All 115 tests pass (`npm test`)
- [ ] README and CHANGELOG rate-limit delay reads 350ms